### PR TITLE
fix: paint when layout has changed

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -4,6 +4,8 @@ export default function ($element, layout) {
   let app = this.$scope.qlik.currApp(this);
   let isEditMode = this.$scope.options.interactionState === 2;
   this.$scope.updatedData(layout, isEditMode, true);
+  this._pureLayout =
+    this.backendApi.model.pureLayout || this.backendApi.model.layout;
   return app.theme.getApplied().then(async (qTheme) => {
     this.$scope.theme = qTheme;
     ThemeManager.setAppTheme(this.$scope.theme);

--- a/src/resize.js
+++ b/src/resize.js
@@ -1,4 +1,7 @@
-export default function($element, layout) {
+export default function ($element, layout) {
+  if (this._pureLayout !== this.backendApi.model.pureLayout) {
+    return this.paint($element, layout);
+  }
   let isEditMode = this.$scope.options.interactionState === 2;
   this.$scope.updatedData(layout, isEditMode, false);
   return this.$scope.qlik.Promise.resolve();


### PR DESCRIPTION
When other charts are in full screen mode and selections are made the chart will not receive any layout updates.
This will store the layout when paint is called and after a resize we check if the layout has changed compared to the last paint.